### PR TITLE
Filter post meta before setting

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -181,6 +181,21 @@ function set_meta( $post_id, $meta ) {
 	$existing_meta    = get_post_meta( $post_id );
 	$blacklisted_meta = blacklisted_meta();
 
+	/**
+	 * Filter the post meta before it is set.
+	 *
+	 * Note: All meta is included in the `$meta` array, including blacklisted keys.
+	 *
+	 * @since 0.0.0
+	 * @hook dt_before_set_meta
+	 *
+	 * @param {array} $meta             All received meta for the post
+	 * @param {array} $existing_meta    Existing meta for the post
+	 * @param {array} $blacklisted_meta Blacklisted meta keys
+	 * @param {int}   $post_id          Post ID
+	 */
+	$meta = apply_filters( 'dt_before_set_meta', $meta, $existing_meta, $blacklisted_meta, $post_id );
+
 	foreach ( $meta as $meta_key => $meta_values ) {
 		if ( in_array( $meta_key, $blacklisted_meta, true ) ) {
 			continue;


### PR DESCRIPTION
**Description of the Change**
Adds a filter for post meta before it is set.

**Benefits**
Allows to filter the post meta before it is set. This is different to blacklisting meta_keys as this allows to change meta_values, or remove some meta entirely, with more control than just the meta_key. 

By having access to the new and existing keys and values, to the destination post ID, and to the original and destination blog (via `get_current_blog_id` and switch stack, respectively) allows for finer control.

One of the cases for this is as follows: 

There are meta with references to attachments and the post with those metas has already been distributed to another site (internal). The handling of pushing those attachments is already being handled via `get_attached_media` and the switching of those references in the meta values on destination is being done on `dt_push_post` (which is called after media is pushed). 

The problem arises on synchronization when the post is saved and pushed via `NetworkSiteConnection::update_syndicated`. During `Utils\prepare_post` in `NetworkSiteConnection::push` we have no way of knowing where the meta that is fetched is going to go to since the connection is not available nor are we already on the destination blog. These meta could be added or not via the `dt_sync_meta` filter but we are missing that crucial element, since it depends on the values on the destination blog.

Without adding anything new, one way would be to interfere in the filters in `get_post_meta` but we would need to be sure that they were only available during distributor actions. Another would be to let distributor update all the meta, and then afterwards use the action `dt_after_set_meta` and update some of the meta keys with the correct values. This creates two unnecessary writes (one with the incorrect value, and one with the correct value after) per each meta_value that should not have been updated.

This "simple" change of adding a filter before metas are set can help alleviate and simplify this handling.

If the references on the destination are already equivalent to the ones coming from the origin, then they need not be written. This verification of equivalence would be done by hooking the filter. This would help when dealing with plugins like `ACF` and `Yoast SEO`, and very likely others that handle references.

If we do not interfere and simply correct the references again on `dt_push_post`, then we run into problems with `get_attached_media` during `Utils\set_media` on the destination post, which will not find the media since the references in the metas are for attachments in origin, leading to Distributor creating duplicates of media that already exists.
